### PR TITLE
fix: reject multiple Host headers

### DIFF
--- a/lib/request.ml
+++ b/lib/request.ml
@@ -56,18 +56,21 @@ module Body_length = struct
 end
 
 let body_length { headers; _ } : Body_length.t =
+  match Headers.get_multi headers "host" with
+  | _ :: _ :: _ -> bad_request
+  | _ ->
   (* The last entry in transfer-encoding is the correct entry. We only accept
      chunked transfer-encodings. *)
-  match List.rev (Headers.get_multi headers "transfer-encoding") with
-  | value :: _ when Headers.ci_equal value "chunked" -> `Chunked
-  | _ :: _ -> bad_request
-  | [] ->
-    (match Message.unique_content_length_values headers with
-    | [] -> `Fixed 0L
-    | [ len ] ->
-      let len = Message.content_length_of_string len in
-      if len >= 0L then `Fixed len else bad_request
-    | _ -> bad_request)
+    (match List.rev (Headers.get_multi headers "transfer-encoding") with
+    | value :: _ when Headers.ci_equal value "chunked" -> `Chunked
+    | _ :: _ -> bad_request
+    | [] ->
+      (match Message.unique_content_length_values headers with
+      | [] -> `Fixed 0L
+      | [ len ] ->
+        let len = Message.content_length_of_string len in
+        if len >= 0L then `Fixed len else bad_request
+      | _ -> bad_request))
 
 let persistent_connection ?proxy { version; headers; _ } =
   Message.persistent_connection ?proxy version headers

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -1628,6 +1628,21 @@ let test_invalid_header_name_characters () =
      X-Invalid[]: test\r\n\
      \r\n"
 
+let test_multiple_host_headers () =
+  let request =
+    Request.create
+      `GET
+      "/"
+      ~headers:
+        (Headers.of_list [ "Host", "example.com"; "Host", "example.org" ])
+  in
+  assert_raw_request_bad_request
+    ~request:(Some request)
+    "GET / HTTP/1.1\r\n\
+     Host: example.com\r\n\
+     Host: example.org\r\n\
+     \r\n"
+
 let test_shutdown_hangs_request_body_read () =
   let got_eof = ref false in
   let request_handler reqd =
@@ -2630,6 +2645,7 @@ let tests =
   ; "failed request parse", `Quick, test_failed_request_parse
   ; "bad request", `Quick, test_bad_request
   ; "invalid header name characters", `Quick, test_invalid_header_name_characters
+  ; "multiple Host headers", `Quick, test_multiple_host_headers
   ; ( "shutdown delivers eof to request bodies"
     , `Quick
     , test_shutdown_hangs_request_body_read )


### PR DESCRIPTION
## Summary
- reject requests that carry more than one `Host` header
- add a server-connection regression covering the `h1spec` multiple-Host case

## Testing
- `dune runtest --no-buffer`
- `PATH="/nix/store/a9d9dk3hbks4xb5p4lrn625ddkb7k6d0-h1spec/bin:$PATH" ./scripts/run-h1spec.sh`