### PR TITLE
fix: reject control characters in header values

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -58,6 +58,10 @@ module P = struct
     | '"' | '/' | '[' | ']' | '?' | '=' | '{' | '}' ->
       false
     | _ -> true
+
+  let is_header_value = function
+    | '\t' | '\032' .. '\126' | '\128' .. '\255' -> true
+    | _ -> false
 end
 
 let unit = return ()
@@ -105,7 +109,7 @@ let header =
   lift2
     (fun key value -> key, value)
     (token <* char ':' <* spaces)
-    (take_till P.is_cr <* eol >>| String.trim)
+    (take_while P.is_header_value <* eol >>| String.trim)
   <* commit
   <?> "header"
 

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -1643,6 +1643,13 @@ let test_multiple_host_headers () =
      Host: example.org\r\n\
      \r\n"
 
+let test_header_value_control_characters () =
+  assert_raw_request_bad_request
+    "GET / HTTP/1.1\r\n\
+     Host: example.com\r\n\
+     X-Bad-Control-Char: test\007\r\n\
+     \r\n"
+
 let test_shutdown_hangs_request_body_read () =
   let got_eof = ref false in
   let request_handler reqd =
@@ -2646,6 +2653,7 @@ let tests =
   ; "bad request", `Quick, test_bad_request
   ; "invalid header name characters", `Quick, test_invalid_header_name_characters
   ; "multiple Host headers", `Quick, test_multiple_host_headers
+  ; "header value control characters", `Quick, test_header_value_control_characters
   ; ( "shutdown delivers eof to request bodies"
     , `Quick
     , test_shutdown_hangs_request_body_read )


### PR DESCRIPTION
## Summary
- reject request header values that contain invalid control characters
- add a server-connection regression covering the `h1spec` bad-control-char case

## Testing
- `dune runtest --no-buffer`
- `PATH="/nix/store/a9d9dk3hbks4xb5p4lrn625ddkb7k6d0-h1spec/bin:$PATH" ./scripts/run-h1spec.sh`