### PR TITLE
fix: reject unsupported HTTP versions

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -92,6 +92,10 @@ let version =
        (fun major minor -> { Version.major; minor })
        (digit <* char '.')
        digit
+  >>= function
+  | ({ Version.major = 1; minor = 0 } | { Version.major = 1; minor = 1 })
+    as version -> return version
+  | _ -> fail "unsupported http version"
 
 let header =
   (* From RFC7230§3.2.4:

--- a/lib_test/test_request.ml
+++ b/lib_test/test_request.ml
@@ -35,7 +35,7 @@ let test_parse_invalid_errors () =
   check "doesn't end" ~expect:(Error ": not enough input") "GET / HTTP/1.1\r\n";
   check
     "invalid version"
-    ~expect:(Error "eol: string")
+    ~expect:(Error ": unsupported http version")
     "GET / HTTP/1.22\r\n\r\n";
   check
     "malformed header"

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -1650,6 +1650,12 @@ let test_header_value_control_characters () =
      X-Bad-Control-Char: test\007\r\n\
      \r\n"
 
+let test_invalid_http_version () =
+  assert_raw_request_bad_request
+    "GET / HTTP/9.9\r\n\
+     Host: example.com\r\n\
+     \r\n"
+
 let test_shutdown_hangs_request_body_read () =
   let got_eof = ref false in
   let request_handler reqd =
@@ -2654,6 +2660,7 @@ let tests =
   ; "invalid header name characters", `Quick, test_invalid_header_name_characters
   ; "multiple Host headers", `Quick, test_multiple_host_headers
   ; "header value control characters", `Quick, test_header_value_control_characters
+  ; "invalid HTTP version", `Quick, test_invalid_http_version
   ; ( "shutdown delivers eof to request bodies"
     , `Quick
     , test_shutdown_hangs_request_body_read )


### PR DESCRIPTION
## Summary
- reject request lines that use unsupported HTTP versions such as `HTTP/9.9`
- add a server-connection regression for the `h1spec` invalid-version case
- update the parser expectation in the request unit test

## Testing
- `dune runtest --no-buffer`
- `PATH="/nix/store/a9d9dk3hbks4xb5p4lrn625ddkb7k6d0-h1spec/bin:$PATH" ./scripts/run-h1spec.sh`