### PR TITLE
fix: reject request lines without an HTTP version

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -127,12 +127,17 @@ let headers =
 
 let request =
   let meth = take_till P.is_space >>| Method.of_string in
+  let request_version =
+    peek_char_fail >>= function
+    | 'H' -> version
+    | _ -> fail "missing http version"
+  in
   lift4
     (fun meth target version headers ->
        Request.create ~version ~headers meth target)
     (meth <* char ' ')
-    (take_till P.is_space <* char ' ')
-    (version <* eol <* commit)
+    (take_till P.is_space <* char ' ' <* commit)
+    (request_version <* eol <* commit)
     (headers <* eol)
 
 let response =

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -1656,6 +1656,9 @@ let test_invalid_http_version () =
      Host: example.com\r\n\
      \r\n"
 
+let test_missing_http_version () =
+  assert_raw_request_bad_request "GET / \r\n\r\n"
+
 let test_shutdown_hangs_request_body_read () =
   let got_eof = ref false in
   let request_handler reqd =
@@ -2661,6 +2664,7 @@ let tests =
   ; "multiple Host headers", `Quick, test_multiple_host_headers
   ; "header value control characters", `Quick, test_header_value_control_characters
   ; "invalid HTTP version", `Quick, test_invalid_http_version
+  ; "missing HTTP version", `Quick, test_missing_http_version
   ; ( "shutdown delivers eof to request bodies"
     , `Quick
     , test_shutdown_hangs_request_body_read )


### PR DESCRIPTION
## Summary
- make the request-line version slot fail immediately when it does not begin with `HTTP/`
- keep fragmented request-line parsing intact while rejecting `GET / \r\n\r\n`
- add a server-connection regression covering the `h1spec` missing-version case

## Testing
- `dune runtest --no-buffer`
- `PATH="/nix/store/a9d9dk3hbks4xb5p4lrn625ddkb7k6d0-h1spec/bin:$PATH" ./scripts/run-h1spec.sh`