### PR TITLE
fix: require Host on HTTP/1.1 requests

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -268,7 +268,10 @@ module Reader = struct
   let request handler =
     let rec parser t handler =
       request <* commit >>= fun request ->
-      match Request.body_length request with
+      match Request.validate_headers request with
+      | `Error `Bad_request -> return (Error (`Bad_request request))
+      | `Ok ->
+        (match Request.body_length request with
       | `Error `Bad_request -> return (Error (`Bad_request request))
       | `Fixed 0L ->
         handler request (Body.Reader.create_empty ());
@@ -281,7 +284,7 @@ module Reader = struct
               (Optional_thunk.some (fun () -> wakeup (Lazy.force t)))
         in
         handler request request_body;
-        body ~encoding request_body *> ok
+        body ~encoding request_body *> ok)
     and t = lazy (create (parser t handler)) in
     Lazy.force t
 

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -55,22 +55,25 @@ module Body_length = struct
     | `Error `Bad_request -> Format.pp_print_string fmt "Error: Bad request"
 end
 
+let validate_headers { version; headers; _ } =
+  match version, Headers.get_multi headers "host" with
+  | { Version.major = 1; minor = 1 }, [] -> bad_request
+  | _, _ :: _ :: _ -> bad_request
+  | _ -> `Ok
+
 let body_length { headers; _ } : Body_length.t =
-  match Headers.get_multi headers "host" with
-  | _ :: _ :: _ -> bad_request
-  | _ ->
   (* The last entry in transfer-encoding is the correct entry. We only accept
      chunked transfer-encodings. *)
-    (match List.rev (Headers.get_multi headers "transfer-encoding") with
-    | value :: _ when Headers.ci_equal value "chunked" -> `Chunked
-    | _ :: _ -> bad_request
-    | [] ->
-      (match Message.unique_content_length_values headers with
-      | [] -> `Fixed 0L
-      | [ len ] ->
-        let len = Message.content_length_of_string len in
-        if len >= 0L then `Fixed len else bad_request
-      | _ -> bad_request))
+  match List.rev (Headers.get_multi headers "transfer-encoding") with
+  | value :: _ when Headers.ci_equal value "chunked" -> `Chunked
+  | _ :: _ -> bad_request
+  | [] ->
+    (match Message.unique_content_length_values headers with
+    | [] -> `Fixed 0L
+    | [ len ] ->
+      let len = Message.content_length_of_string len in
+      if len >= 0L then `Fixed len else bad_request
+    | _ -> bad_request)
 
 let persistent_connection ?proxy { version; headers; _ } =
   Message.persistent_connection ?proxy version headers

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -225,8 +225,21 @@ let force_read_string t str =
   let c = force_feed_string t str in
   Alcotest.(check int) "read consumes all input" (String.length str) c
 
+let request_to_server_string (request : Request.t) =
+  let request =
+    if Version.compare request.version Version.v1_1 = 0
+       && not (Headers.mem request.headers "host")
+    then
+      { request with
+        headers =
+          Headers.add_unless_exists request.headers "host" "example.com"
+      }
+    else request
+  in
+  request_to_string request
+
 let read_request ?eof t r =
-  let request_string = request_to_string r in
+  let request_string = request_to_server_string r in
   read_string ?eof t request_string
 
 let reader_ready ?(msg = "Reader is ready") t =
@@ -382,7 +395,11 @@ let test_commit_parse_after_every_header () =
   let single_header = "Links: /path/to/some/website\r\n" in
   let r =
     (* Each header is 30 bytes *)
-    request_line ^ single_header ^ single_header ^ "connection: close\r\n\r\n"
+    request_line
+    ^ single_header
+    ^ single_header
+    ^ "Host: example.com\r\n"
+    ^ "connection: close\r\n\r\n"
   in
   let bs = Bigstringaf.of_string r ~off:0 ~len:(String.length r) in
   let c = read t bs ~off:0 ~len:30 in
@@ -1583,7 +1600,10 @@ let test_bad_request () =
   (* A `Bad_request is returned in a number of cases surrounding
      transfer-encoding or content-length headers. *)
   let request =
-    Request.create `GET "/" ~headers:(Headers.encoding_fixed (-1))
+    Request.create
+      `GET
+      "/"
+      ~headers:(Headers.of_list [ "host", "example.com"; "content-length", "-1" ])
   in
   let error_handler_fired = ref false in
   let error_handler ?request:request' error start_response =
@@ -1658,6 +1678,19 @@ let test_invalid_http_version () =
 
 let test_missing_http_version () =
   assert_raw_request_bad_request "GET / \r\n\r\n"
+
+let test_missing_host_header () =
+  let request =
+    Request.create
+      `GET
+      "/"
+      ~headers:(Headers.of_list [ "Content-Length", "5" ])
+  in
+  assert_raw_request_bad_request
+    ~request:(Some request)
+    "GET / HTTP/1.1\r\n\
+     Content-Length: 5\r\n\
+     \r\n"
 
 let test_shutdown_hangs_request_body_read () =
   let got_eof = ref false in
@@ -1908,8 +1941,8 @@ let test_multiple_requests_in_single_read () =
   let response = Response.create `OK in
   let t = create (fun reqd -> Reqd.respond_with_string reqd response "") in
   let reqs =
-    request_to_string (Request.create `GET "/")
-    ^ request_to_string (Request.create `GET "/")
+    request_to_server_string (Request.create `GET "/")
+    ^ request_to_server_string (Request.create `GET "/")
   in
   read_string t reqs;
 
@@ -1926,8 +1959,8 @@ let test_multiple_async_requests_in_single_read () =
       finish_handler := fun () -> Reqd.respond_with_string reqd response "")
   in
   let reqs =
-    request_to_string (Request.create `GET "/")
-    ^ request_to_string (Request.create `GET "/")
+    request_to_server_string (Request.create `GET "/")
+    ^ request_to_server_string (Request.create `GET "/")
   in
   read_string t reqs;
   reader_yielded t;
@@ -1957,8 +1990,8 @@ let test_multiple_requests_in_single_read_with_close () =
   let response = Response.create `OK ~headers:Headers.connection_close in
   let t = create (fun reqd -> Reqd.respond_with_string reqd response "") in
   let reqs =
-    request_to_string (Request.create `GET "/")
-    ^ request_to_string (Request.create `GET "/")
+    request_to_server_string (Request.create `GET "/")
+    ^ request_to_server_string (Request.create `GET "/")
   in
   read_string t reqs;
   write_response t response;
@@ -2008,8 +2041,8 @@ let test_multiple_requests_in_single_read_with_eof () =
   let response = Response.create `OK in
   let t = create (fun reqd -> Reqd.respond_with_string reqd response "") in
   let reqs =
-    request_to_string (Request.create `GET "/")
-    ^ request_to_string (Request.create `GET "/")
+    request_to_server_string (Request.create `GET "/")
+    ^ request_to_server_string (Request.create `GET "/")
   in
   read_string t reqs ~eof:true;
   write_string t (response_to_string response);
@@ -2348,7 +2381,9 @@ let test_pipelined_requests_in_single_buffer_partial_body () =
   in
   let t = create request_handler in
   let req = Request.create `POST "/" ~headers:(Headers.encoding_fixed 5) in
-  let reqs = request_to_string req ^ "hello" ^ request_to_string req in
+  let reqs =
+    request_to_server_string req ^ "hello" ^ request_to_server_string req
+  in
   read_string t reqs;
   reader_yielded t;
   write_response t ~body:"hello" response;
@@ -2376,7 +2411,7 @@ let test_multiple_pipelined_requests () =
   in
   let t = create request_handler in
   let req = Request.create `POST "/" ~headers:(Headers.encoding_fixed 5) in
-  read_string t (request_to_string req ^ "hello");
+  read_string t (request_to_server_string req ^ "hello");
   reader_yielded t;
 
   write_response t ~body:"hello" response;
@@ -2388,7 +2423,7 @@ let test_multiple_pipelined_requests () =
   in
   reader_ready t;
 
-  let reqs = "hello" ^ request_to_string req ^ "hello" in
+  let reqs = "hello" ^ request_to_server_string req ^ "hello" in
   read_string t reqs;
   Alcotest.(check bool) "Writer woken up" true !writer_woken_up;
   reader_yielded t;
@@ -2510,7 +2545,11 @@ let test_write_response_after_read_eof () =
   let single_header = "Links: /path/to/some/website\r\n" in
   let r =
     (* Each header is 30 bytes *)
-    request_line ^ single_header ^ single_header ^ "connection: close\r\n\r\n"
+    request_line
+    ^ single_header
+    ^ single_header
+    ^ "Host: example.com\r\n"
+    ^ "connection: close\r\n\r\n"
   in
   let bs = Bigstringaf.of_string r ~off:0 ~len:(String.length r) in
   let c = read t bs ~off:0 ~len:30 in
@@ -2665,6 +2704,7 @@ let tests =
   ; "header value control characters", `Quick, test_header_value_control_characters
   ; "invalid HTTP version", `Quick, test_invalid_http_version
   ; "missing HTTP version", `Quick, test_missing_http_version
+  ; "missing Host header", `Quick, test_missing_host_header
   ; ( "shutdown delivers eof to request bodies"
     , `Quick
     , test_shutdown_hangs_request_body_read )


### PR DESCRIPTION
## Summary
- reject HTTP/1.1 requests that omit the required `Host` header
- validate request header structure before selecting the body reader
- add a server-connection regression covering the `h1spec` missing-Host case

## Testing
- `dune runtest --no-buffer`
- `nix develop -c make h1spec`