### PR TITLE
perf: remove body-parser chunk allocations

### DIFF
--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -14,6 +14,11 @@
  (modules Wrk_lwt_benchmark)
  (libraries httpun httpun_examples httpun-lwt-unix lwt.unix base))
 
+(executable
+ (name large_transfer_lwt_benchmark)
+ (modules large_transfer_lwt_benchmark)
+ (libraries httpun httpun-lwt-unix lwt.unix base))
+
 (alias
  (name benchmarks)
  (deps

--- a/benchmarks/large_transfer_lwt_benchmark.ml
+++ b/benchmarks/large_transfer_lwt_benchmark.ml
@@ -1,0 +1,496 @@
+open Base
+open Httpun
+open Httpun_lwt_unix
+open Lwt.Infix
+
+module Arg = Stdlib.Arg
+module Printf = Stdlib.Printf
+
+type measurement =
+  { name : string
+  ; bytes : int64
+  ; seconds : float
+  }
+
+type writer_mode =
+  | Copy
+  | Schedule
+  | Queue_schedule
+
+let default_path =
+  let home =
+    match Sys.getenv "HOME" with
+    | Some home -> home
+    | None -> "."
+  in
+  Stdlib.Filename.concat home "Downloads/x.zip"
+
+let await_flush writer =
+  let finished, notify_finished = Lwt.wait () in
+  Body.Writer.flush writer (function
+    | `Written -> Lwt.wakeup_later notify_finished ()
+    | `Closed ->
+      Lwt.wakeup_later_exn
+        notify_finished
+        (Failure "connection closed while flushing body writer"));
+  finished
+
+let with_open_file path flags perm f =
+  Lwt_unix.openfile path flags perm >>= fun fd ->
+  Lwt.finalize (fun () -> f fd) (fun () -> Lwt_unix.close fd)
+
+let make_config ~read_buffer_size ~body_buffer_size =
+  { Httpun.Config.default with
+    read_buffer_size
+  ; request_body_buffer_size = body_buffer_size
+  ; response_body_buffer_size = body_buffer_size
+  }
+
+let read_file_size path =
+  let stats = Unix.LargeFile.stat path in
+  stats.Unix.LargeFile.st_size
+
+let writer_mode_to_string = function
+  | Copy -> "copy"
+  | Schedule -> "schedule"
+  | Queue_schedule -> "queue-schedule"
+
+let writer_mode_of_string = function
+  | "copy" -> Copy
+  | "schedule" -> Schedule
+  | "queue-schedule" -> Queue_schedule
+  | mode ->
+    failwith
+      (Printf.sprintf
+         "unknown writer mode %S (expected copy|schedule|queue-schedule)"
+         mode)
+
+let write_chunk writer_mode writer buffer ~len =
+  match writer_mode with
+  | Copy -> Body.Writer.write_bigstring writer buffer ~off:0 ~len
+  | Schedule -> Body.Writer.schedule_bigstring writer buffer ~off:0 ~len
+  | Queue_schedule -> Body.Writer.schedule_bigstring writer buffer ~off:0 ~len
+
+type slot =
+  { buffer : Lwt_bytes.t
+  ; mutable ready : unit Lwt.t
+  }
+
+let rec stream_fd_to_writer
+          fd
+          writer
+          ~writer_mode
+          ~buffer
+          ~chunk_size
+          ~written
+  =
+  Lwt_bytes.read fd buffer 0 chunk_size >>= function
+  | 0 ->
+    Body.Writer.close writer;
+    Lwt.return written
+  | len ->
+    write_chunk writer_mode writer buffer ~len;
+    await_flush writer >>= fun () ->
+    stream_fd_to_writer
+      fd
+      writer
+      ~writer_mode
+      ~buffer
+      ~chunk_size
+      ~written:Int64.(written + of_int len)
+
+let stream_fd_to_writer_queued
+      fd
+      writer
+      ~buffer_count
+      ~chunk_size
+      ~written
+  =
+  let slots =
+    Array.init buffer_count ~f:(fun _ ->
+      { buffer = Lwt_bytes.create chunk_size; ready = Lwt.return_unit })
+  in
+  let rec loop slot_index written =
+    let slot = Array.unsafe_get slots slot_index in
+    slot.ready >>= fun () ->
+    Lwt_bytes.read fd slot.buffer 0 chunk_size >>= function
+    | 0 ->
+      Lwt_list.iter_s (fun slot -> slot.ready) (Array.to_list slots) >>= fun () ->
+      Body.Writer.close writer;
+      Lwt.return written
+    | len ->
+      Body.Writer.schedule_bigstring writer slot.buffer ~off:0 ~len;
+      let ready, notify_ready = Lwt.wait () in
+      Body.Writer.flush writer (function
+        | `Written -> Lwt.wakeup_later notify_ready ()
+        | `Closed ->
+          Lwt.wakeup_later_exn
+            notify_ready
+            (Failure "connection closed while flushing body writer"));
+      slot.ready <- ready;
+      loop
+        (Int.rem (slot_index + 1) buffer_count)
+        Int64.(written + of_int len)
+  in
+  loop 0 written
+
+let rec consume_request_body reader bytes_seen on_finished =
+  Body.Reader.schedule_read
+    reader
+    ~on_eof:(fun () -> on_finished !bytes_seen)
+    ~on_read:(fun _buffer ~off:_ ~len ->
+      bytes_seen := Int64.(!bytes_seen + of_int len);
+      consume_request_body reader bytes_seen on_finished)
+
+let error_handler _client_addr ?request:_ error start_response =
+  let response_body = start_response Headers.empty in
+  let message =
+    match error with
+    | `Bad_request -> "bad request"
+    | `Bad_gateway -> "bad gateway"
+    | `Internal_server_error -> "internal server error"
+    | `Exn exn -> Exn.to_string exn
+  in
+  Body.Writer.write_string response_body message;
+  Body.Writer.close response_body
+
+let create_request_handler
+      ~path
+      ~chunk_size
+      ~file_size
+      ~writer_mode
+      ~buffer_count
+      _client_addr
+      { Gluten.reqd; _ }
+  =
+  match Reqd.request reqd with
+  | { Request.meth = `GET; target = "/download"; _ } ->
+    let headers =
+      Headers.of_list
+        [ "content-length", Int64.to_string file_size
+        ; "content-type", "application/octet-stream"
+        ; "connection", "close"
+        ]
+    in
+    let response_body =
+      Reqd.respond_with_streaming reqd (Response.create ~headers `OK)
+    in
+    let buffer = Lwt_bytes.create chunk_size in
+    Lwt.async (fun () ->
+      with_open_file path [ Unix.O_RDONLY ] 0 (fun fd ->
+        (match writer_mode with
+        | Queue_schedule ->
+          stream_fd_to_writer_queued
+            fd
+            response_body
+            ~buffer_count
+            ~chunk_size
+            ~written:0L
+        | Copy | Schedule ->
+          stream_fd_to_writer
+            fd
+            response_body
+            ~writer_mode
+            ~buffer
+            ~chunk_size
+            ~written:0L)
+        >|= ignore))
+  | { Request.meth = `POST; target = "/upload"; _ } ->
+    let request_body = Reqd.request_body reqd in
+    let bytes_seen = ref 0L in
+    consume_request_body request_body bytes_seen (fun received ->
+      let headers =
+        Headers.of_list
+          [ "content-length", "0"
+          ; "connection", "close"
+          ; "x-bytes-received", Int64.to_string received
+          ]
+      in
+      Reqd.respond_with_string reqd (Response.create ~headers `OK) "")
+  | _ ->
+    let headers =
+      Headers.of_list [ "content-length", "0"; "connection", "close" ]
+    in
+    Reqd.respond_with_string reqd (Response.create ~headers `Not_found) ""
+
+let start_server ~path ~chunk_size ~file_size ~writer_mode ~buffer_count ~config =
+  let listen_socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Lwt_unix.setsockopt listen_socket Unix.SO_REUSEADDR true;
+  let listen_addr = Unix.ADDR_INET (Unix.inet_addr_loopback, 0) in
+  Lwt_unix.bind listen_socket listen_addr >>= fun () ->
+  Lwt_unix.listen listen_socket 128;
+  let request_handler =
+    create_request_handler
+      ~path
+      ~chunk_size
+      ~file_size
+      ~writer_mode
+      ~buffer_count
+  in
+  let connection_handler =
+    Server.create_connection_handler ~config ~request_handler ~error_handler
+  in
+  let rec accept_loop () =
+    Lwt.catch
+      (fun () ->
+        Lwt_unix.accept listen_socket >>= fun (client_socket, client_addr) ->
+        Lwt.async (fun () -> connection_handler client_addr client_socket);
+        accept_loop ())
+      (function
+        | Unix.Unix_error ((Unix.EBADF | Unix.EINVAL), _, _) -> Lwt.return_unit
+        | exn -> Lwt.fail exn)
+  in
+  Lwt.async accept_loop;
+  let port =
+    match Lwt_unix.getsockname listen_socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | Unix.ADDR_UNIX _ -> failwith "expected an INET listener"
+  in
+  let stop () = Lwt_unix.close listen_socket in
+  Lwt.return (port, stop)
+
+let with_connection ~config port f =
+  let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  let sockaddr = Unix.ADDR_INET (Unix.inet_addr_loopback, port) in
+  Lwt_unix.connect socket sockaddr >>= fun () ->
+  Lwt.finalize
+    (fun () ->
+      Client.create_connection ~config socket >>= fun connection -> f connection)
+    (fun () ->
+      Lwt.catch
+        (fun () -> Lwt_unix.close socket)
+        (fun _ -> Lwt.return_unit))
+
+let run_download ~config ~port ~host ~expected_bytes =
+  let started_at = Unix.gettimeofday () in
+  let finished, notify_finished = Lwt.wait () in
+  let error_handler error =
+    let message =
+      match error with
+      | `Malformed_response err -> "malformed response: " ^ err
+      | `Invalid_response_body_length _ -> "invalid response body length"
+      | `Exn exn -> Exn.to_string exn
+    in
+    Lwt.wakeup_later_exn notify_finished (Failure message)
+  in
+  let response_handler response response_body =
+    match response with
+    | { Response.status = `OK; _ } ->
+      let bytes_received = ref 0L in
+      let rec on_read _buffer ~off:_ ~len =
+        bytes_received := Int64.(!bytes_received + of_int len);
+        Body.Reader.schedule_read response_body ~on_eof ~on_read
+      and on_eof () =
+        let bytes_received = !bytes_received in
+        if Int64.(bytes_received <> expected_bytes)
+        then
+          Lwt.wakeup_later_exn
+            notify_finished
+            (Failure
+               (Printf.sprintf
+                  "downloaded %Ld bytes, expected %Ld"
+                  bytes_received
+                  expected_bytes))
+        else Lwt.wakeup_later notify_finished bytes_received
+      in
+      Body.Reader.schedule_read response_body ~on_eof ~on_read
+    | response ->
+      Lwt.wakeup_later_exn
+        notify_finished
+        (Failure
+           (Printf.sprintf
+              "unexpected download response status: %d"
+              (Status.to_code response.status)))
+  in
+  with_connection ~config port (fun connection ->
+    let headers =
+      Headers.of_list [ "host", host; "connection", "close" ]
+    in
+    let request_body =
+      Client.request
+        connection
+        ~error_handler
+        ~response_handler
+        (Request.create ~headers `GET "/download")
+    in
+    Body.Writer.close request_body;
+    finished)
+  >|= fun bytes ->
+  { name = "download"
+  ; bytes
+  ; seconds = Unix.gettimeofday () -. started_at
+  }
+
+let run_upload
+      ~config
+      ~path
+      ~port
+      ~host
+      ~expected_bytes
+      ~chunk_size
+      ~writer_mode
+      ~buffer_count
+  =
+  let started_at = Unix.gettimeofday () in
+  let finished, notify_finished = Lwt.wait () in
+  let error_handler error =
+    let message =
+      match error with
+      | `Malformed_response err -> "malformed response: " ^ err
+      | `Invalid_response_body_length _ -> "invalid response body length"
+      | `Exn exn -> Exn.to_string exn
+    in
+    Lwt.wakeup_later_exn notify_finished (Failure message)
+  in
+  let response_handler response response_body =
+    match response with
+    | { Response.status = `OK; headers; _ } ->
+      let received =
+        match Headers.get headers "x-bytes-received" with
+        | None -> 0L
+        | Some received -> Int64.of_string received
+      in
+      let on_eof () =
+        if Int64.(received <> expected_bytes)
+        then
+          Lwt.wakeup_later_exn
+            notify_finished
+            (Failure
+               (Printf.sprintf
+                  "server received %Ld bytes, expected %Ld"
+                  received
+                  expected_bytes))
+        else Lwt.wakeup_later notify_finished received
+      in
+      Body.Reader.schedule_read response_body ~on_eof ~on_read:(fun _ ~off:_ ~len:_ -> ())
+    | response ->
+      Lwt.wakeup_later_exn
+        notify_finished
+        (Failure
+           (Printf.sprintf
+              "unexpected upload response status: %d"
+              (Status.to_code response.status)))
+  in
+  with_connection ~config port (fun connection ->
+    let headers =
+      Headers.of_list
+        [ "host", host
+        ; "connection", "close"
+        ; "content-length", Int64.to_string expected_bytes
+        ; "content-type", "application/octet-stream"
+        ]
+    in
+    let request_body =
+      Client.request
+        connection
+        ~error_handler
+        ~response_handler
+        (Request.create ~headers `POST "/upload")
+    in
+    let buffer = Lwt_bytes.create chunk_size in
+    let send_request_body =
+      with_open_file path [ Unix.O_RDONLY ] 0 (fun fd ->
+        match writer_mode with
+        | Queue_schedule ->
+          stream_fd_to_writer_queued
+            fd
+            request_body
+            ~buffer_count
+            ~chunk_size
+            ~written:0L
+        | Copy | Schedule ->
+          stream_fd_to_writer
+            fd
+            request_body
+            ~writer_mode
+            ~buffer
+            ~chunk_size
+            ~written:0L)
+    in
+    Lwt.both send_request_body finished >|= fun (written, received) ->
+    if Int64.(written <> expected_bytes)
+    then
+      failwith
+        (Printf.sprintf
+           "uploaded %Ld bytes from disk, expected %Ld"
+           written
+           expected_bytes);
+    received)
+  >|= fun bytes ->
+  { name = "upload"
+  ; bytes
+  ; seconds = Unix.gettimeofday () -. started_at
+  }
+
+let format_throughput bytes seconds =
+  let mib_per_second =
+    Int64.to_float bytes /. (1024. *. 1024.) /. seconds
+  in
+  Printf.sprintf "%.2f MiB/s" mib_per_second
+
+let print_measurement measurement =
+  Printf.printf
+    "%s: %Ld bytes in %.3fs (%s)\n%!"
+    measurement.name
+    measurement.bytes
+    measurement.seconds
+    (format_throughput measurement.bytes measurement.seconds)
+
+let run path chunk_size writer_mode buffer_count =
+  let file_size = read_file_size path in
+  let config =
+    make_config ~read_buffer_size:chunk_size ~body_buffer_size:chunk_size
+  in
+  Printf.printf
+    "Benchmark file: %s\nsize: %Ld bytes\nchunk size: %d bytes\nwriter mode: \
+     %s\nbuffer count: %d\n\
+     %!"
+    path
+    file_size
+    chunk_size
+    (writer_mode_to_string writer_mode)
+    buffer_count;
+  start_server ~path ~chunk_size ~file_size ~writer_mode ~buffer_count ~config
+  >>= fun (port, stop_server) ->
+  let host = "127.0.0.1" in
+  Lwt.finalize
+    (fun () ->
+      run_upload
+        ~config
+        ~path
+        ~port
+        ~host
+        ~expected_bytes:file_size
+        ~chunk_size
+        ~writer_mode
+        ~buffer_count
+      >>= fun upload ->
+      run_download ~config ~port ~host ~expected_bytes:file_size
+      >>= fun download ->
+      print_measurement upload;
+      print_measurement download;
+      Lwt.return_unit)
+    stop_server
+
+let () =
+  let path = ref default_path in
+  let chunk_size = ref (1024 * 1024) in
+  let writer_mode = ref Copy in
+  let buffer_count = ref 4 in
+  Arg.parse
+    [ "-f", Arg.Set_string path, " Path to the file to transfer"
+    ; "-c", Arg.Set_int chunk_size, " Chunk size in bytes (default: 1048576)"
+    ; ( "-m"
+      , Arg.String (fun mode -> writer_mode := writer_mode_of_string mode)
+      , " Writer mode: copy, schedule, or queue-schedule (default: copy)" )
+    ; ( "-b"
+      , Arg.Set_int buffer_count
+      , " Number of rotating buffers for queue-schedule mode (default: 4)" )
+    ]
+    ignore
+    "large_transfer_lwt_benchmark.exe";
+  if not (Stdlib.Sys.file_exists !path)
+  then failwith (Printf.sprintf "file does not exist: %s" !path);
+  if !chunk_size <= 0 then failwith "chunk size must be positive";
+  if !buffer_count <= 0 then failwith "buffer count must be positive";
+  Lwt_main.run (run !path !chunk_size !writer_mode !buffer_count)

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -63,7 +63,10 @@ let wakeup_writer t = Writer.wakeup t.writer
 let create ?(config = Config.default) () =
   let request_queue = Queue.create () in
   { config
-  ; reader = Reader.response request_queue
+  ; reader =
+      Reader.response
+        ~body_buffer_size:config.response_body_buffer_size
+        request_queue
   ; writer = Writer.create ()
   ; request_queue
   }

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -62,11 +62,9 @@ let wakeup_writer t = Writer.wakeup t.writer
 
 let create ?(config = Config.default) () =
   let request_queue = Queue.create () in
+  let response_body_buffer = Bigstringaf.create config.response_body_buffer_size in
   { config
-  ; reader =
-      Reader.response
-        ~body_buffer_size:config.response_body_buffer_size
-        request_queue
+  ; reader = Reader.response ~body_buffer:response_body_buffer request_queue
   ; writer = Writer.create ()
   ; request_queue
   }

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -150,12 +150,11 @@ let finish body =
 
 let schedule_size body n =
   let faraday = Body.Reader.unsafe_faraday body in
-  (* XXX(seliopou): performance regression due to switching to a single output *
-     format in Farady. Once a specialized operation is exposed to avoid the *
-     intemediate copy, this should be back to the original performance. *)
   (if Faraday.is_closed faraday
    then advance n
-   else take_bigstring n >>| fun s -> Faraday.schedule_bigstring faraday s)
+   else
+     Unsafe.take n (fun buffer ~off ~len ->
+       Faraday.write_bigstring faraday buffer ~off ~len))
   *> commit
 
 let body ~encoding body =
@@ -252,7 +251,7 @@ module Reader = struct
     t.wakeup <- Optional_thunk.none;
     Optional_thunk.call_if_some f
 
-  let request handler =
+  let request ~body_buffer_size handler =
     let rec parser t handler =
       request <* commit >>= fun request ->
       match Request.body_length request with
@@ -263,7 +262,7 @@ module Reader = struct
       | (`Fixed _ | `Chunked) as encoding ->
         let request_body =
           Body.Reader.create
-            Bigstringaf.empty
+            (Bigstringaf.create body_buffer_size)
             ~when_ready_to_read:
               (Optional_thunk.some (fun () -> wakeup (Lazy.force t)))
         in
@@ -272,7 +271,7 @@ module Reader = struct
     and t = lazy (create (parser t handler)) in
     Lazy.force t
 
-  let response request_queue =
+  let response ~body_buffer_size request_queue =
     let parser t request_queue =
       response <* commit >>= fun response ->
       assert (not (Queue.is_empty request_queue));
@@ -303,7 +302,7 @@ module Reader = struct
            client could DOS easily. *)
         let response_body =
           Body.Reader.create
-            Bigstringaf.empty
+            (Bigstringaf.create body_buffer_size)
             ~when_ready_to_read:
               (Optional_thunk.some (fun () -> wakeup (Lazy.force t)))
         in

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -251,7 +251,7 @@ module Reader = struct
     t.wakeup <- Optional_thunk.none;
     Optional_thunk.call_if_some f
 
-  let request ~body_buffer_size handler =
+  let request ~body_buffer handler =
     let rec parser t handler =
       request <* commit >>= fun request ->
       match Request.body_length request with
@@ -262,7 +262,7 @@ module Reader = struct
       | (`Fixed _ | `Chunked) as encoding ->
         let request_body =
           Body.Reader.create
-            (Bigstringaf.create body_buffer_size)
+            body_buffer
             ~when_ready_to_read:
               (Optional_thunk.some (fun () -> wakeup (Lazy.force t)))
         in
@@ -271,7 +271,7 @@ module Reader = struct
     and t = lazy (create (parser t handler)) in
     Lazy.force t
 
-  let response ~body_buffer_size request_queue =
+  let response ~body_buffer request_queue =
     let parser t request_queue =
       response <* commit >>= fun response ->
       assert (not (Queue.is_empty request_queue));
@@ -302,7 +302,7 @@ module Reader = struct
            client could DOS easily. *)
         let response_body =
           Body.Reader.create
-            (Bigstringaf.create body_buffer_size)
+            body_buffer
             ~when_ready_to_read:
               (Optional_thunk.some (fun () -> wakeup (Lazy.force t)))
         in

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -102,11 +102,19 @@ let create
       ?(error_handler = default_error_handler)
       request_handler
   =
-  let { Config.response_buffer_size; response_body_buffer_size; _ } = config in
+  let
+    { Config.response_buffer_size
+    ; response_body_buffer_size
+    ; request_body_buffer_size
+    ; _
+    }
+    =
+    config
+  in
   let writer = Writer.create ~buffer_size:response_buffer_size () in
   let request_queue = Queue.create () in
   let response_body_buffer = Bigstringaf.create response_body_buffer_size in
-  let rec reader = lazy (Reader.request handler)
+  let rec reader = lazy (Reader.request ~body_buffer_size:request_body_buffer_size handler)
   and handler request request_body =
     let reqd =
       Reqd.create

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -113,8 +113,9 @@ let create
   in
   let writer = Writer.create ~buffer_size:response_buffer_size () in
   let request_queue = Queue.create () in
+  let request_body_buffer = Bigstringaf.create request_body_buffer_size in
   let response_body_buffer = Bigstringaf.create response_body_buffer_size in
-  let rec reader = lazy (Reader.request ~body_buffer_size:request_body_buffer_size handler)
+  let rec reader = lazy (Reader.request ~body_buffer:request_body_buffer handler)
   and handler request request_body =
     let reqd =
       Reqd.create


### PR DESCRIPTION
## Summary
- avoid allocating a fresh bigstring for every parsed body chunk
- reuse one inbound body buffer per connection instead of allocating a new body buffer for each non-empty request/response body
- keep zero-length bodies on the existing `Body.Reader.create_empty ()` path
- add a large-transfer benchmark for 1.5GB upload/download throughput measurements

## Implementation
The parser now copies body bytes directly out of Angstrom's parse buffer into the `Body.Reader` Faraday buffer with `Unsafe.take` + `Faraday.write_bigstring`, instead of materializing an intermediate bigstring for every chunk.

For inbound streaming bodies, the client and server now each allocate a single reusable body buffer at connection creation and pass that shared buffer into the parser. That avoids the eager per-body `Bigstringaf.create` that the first version of this PR introduced.

## Validation
- `XDG_CONFIG_HOME=$(mktemp -d) dune build lib/httpun.cmxa benchmarks/large_transfer_lwt_benchmark.exe`
- `XDG_CONFIG_HOME=$(mktemp -d) dune runtest --no-buffer`
- repeated direct runs of `./_build/default/benchmarks/large_transfer_lwt_benchmark.exe -f "$HOME/Downloads/x.zip" -c ... -m copy`

## Benchmark
Using `/Users/anmonteiro/Downloads/x.zip` (`1,447,894,451` bytes) on loopback.

### 1 MiB chunks
Repeated serial runs on `master` (benchmark harness only):
- upload: `3039.04`, `3384.46`, `3477.73` MiB/s
- download: `3132.64`, `3243.40`, `4139.68` MiB/s

Repeated serial runs on this branch:
- upload: `4203.68`, `4054.94`, `4100.66` MiB/s
- download: `4744.33`, `3928.87`, `3816.99` MiB/s

Approximate mean improvement:
- upload: `~25%`
- download: `~19%`

### 64 KiB chunks
Repeated serial runs on `master`:
- upload: `1849.24`, `1771.40` MiB/s
- download: `1835.59`, `1870.56` MiB/s

Repeated serial runs on this branch:
- upload: `1930.15`, `1892.07` MiB/s
- download: `1967.87`, `1953.11` MiB/s

Approximate mean improvement:
- upload: `~6%`
- download: `~6%`

The earlier near-2x single-run result did not hold up under repeated serial measurement. The improvement is still real, but the stable result is closer to a `20-25%` gain for large chunks, with smaller gains at `64 KiB`.